### PR TITLE
Updated clause to ensure that zookeeper is not currently running, els…

### DIFF
--- a/templates/kafka.conf.j2
+++ b/templates/kafka.conf.j2
@@ -9,7 +9,7 @@ limit nofile 32768 32768
 
 # If zookeeper is running on this box also give it time to start up properly
 pre-start script
-    if [ -e /etc/init.d/zookeeper ]; then
+    if [ -e /etc/init.d/zookeeper ] && [ -n `status zookeeper | grep stop`]; then
         /etc/init.d/zookeeper start
     fi
 end script


### PR DESCRIPTION
…e upstart fails to start kafka in the event zookeeper is already running.