### PR TITLE
Fix test to see if zookeeper is stopped

### DIFF
--- a/templates/kafka.conf.j2
+++ b/templates/kafka.conf.j2
@@ -9,7 +9,7 @@ limit nofile 32768 32768
 
 # If zookeeper is running on this box also give it time to start up properly
 pre-start script
-    if [ -e /etc/init.d/zookeeper ] && [ -n `status zookeeper | grep stop`]; then
+    if [ -e /etc/init.d/zookeeper ] && [[ -n `status zookeeper | grep stop` ]]; then
         /etc/init.d/zookeeper start
     fi
 end script


### PR DESCRIPTION
Based on http://stackoverflow.com/questions/3869072/test-for-non-zero-
length-string-in-bash-n-var-or-var